### PR TITLE
fix the full test suite

### DIFF
--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
         nSum += nSubsidy;
         BOOST_CHECK(MoneyRange(nSum));
     }
-    BOOST_CHECK_EQUAL(nSum, 12500000000000ULL);
+    BOOST_CHECK_EQUAL(nSum, 1250000000ULL);
     // Remainder of first period
     for (int nHeight = consensusParams.nSubsidySlowStartInterval; nHeight < consensusParams.nSubsidyHalvingInterval + consensusParams.SubsidySlowStartShift(); nHeight ++) {
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);


### PR DESCRIPTION
test previously failing due to having zcash slow start values leftover.

@mountaindrifter adjusted the main value, it passes the test, but some further work may need to be done for 1.0.4 -- please refer to https://github.com/z-classic/zclassic/issues/34
