### PR TITLE
Allow reedeeming of previously replay protected transactions

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -378,8 +378,20 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
 
                     break;
                 }
+                case OP_NOP5:
+                {
+                    if (stack.size() == 2) {
+                        popstack(stack);
+                        popstack(stack);
+                    }
+                    else {
+                        if (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS)
+                            return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS);
+                    }
+                }
+                break;
 
-                case OP_NOP1: case OP_NOP3: case OP_NOP4: case OP_NOP5:
+                case OP_NOP1: case OP_NOP3: case OP_NOP4:
                 case OP_NOP6: case OP_NOP7: case OP_NOP8: case OP_NOP9: case OP_NOP10:
                 {
                     if (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS)

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -26,7 +26,9 @@ const char* GetTxnOutputType(txnouttype t)
     {
     case TX_NONSTANDARD: return "nonstandard";
     case TX_PUBKEY: return "pubkey";
+    case TX_PUBKEY_REPLAY: return "pubkeyreplay";
     case TX_PUBKEYHASH: return "pubkeyhash";
+    case TX_PUBKEYHASH_REPLAY: return "pubkeyhashreplay";
     case TX_SCRIPTHASH: return "scripthash";
     case TX_MULTISIG: return "multisig";
     case TX_NULL_DATA: return "nulldata";
@@ -45,9 +47,11 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
     {
         // Standard tx, sender provides pubkey, receiver adds signature
         mTemplates.insert(make_pair(TX_PUBKEY, CScript() << OP_PUBKEY << OP_CHECKSIG));
+        mTemplates.insert(make_pair(TX_PUBKEY_REPLAY, CScript() << OP_PUBKEY << OP_CHECKSIG << OP_SMALLDATA << OP_SMALLDATA << OP_NOP5));
 
         // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey
         mTemplates.insert(make_pair(TX_PUBKEYHASH, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG));
+        mTemplates.insert(make_pair(TX_PUBKEYHASH_REPLAY, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG << OP_SMALLDATA << OP_SMALLDATA << OP_NOP5));
 
         // Sender provides N pubkeys, receivers provides M signatures
         mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -31,6 +31,7 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_PUBKEYHASH_REPLAY: return "pubkeyhashreplay";
     case TX_SCRIPTHASH: return "scripthash";
     case TX_MULTISIG: return "multisig";
+    case TX_MULTISIG_REPLAY: return "multisigreplay";
     case TX_NULL_DATA: return "nulldata";
     }
     return NULL;
@@ -55,6 +56,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
 
         // Sender provides N pubkeys, receivers provides M signatures
         mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
+        mTemplates.insert(make_pair(TX_MULTISIG_REPLAY, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG << OP_SMALLDATA << OP_SMALLDATA << OP_NOP5));
 
         // Empty, provably prunable, data-carrying output
         if (GetBoolArg("-datacarrier", true))

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -62,7 +62,9 @@ enum txnouttype
     TX_NONSTANDARD,
     // 'standard' transaction types:
     TX_PUBKEY,
+    TX_PUBKEY_REPLAY,
     TX_PUBKEYHASH,
+    TX_PUBKEYHASH_REPLAY,
     TX_SCRIPTHASH,
     TX_MULTISIG,
     TX_NULL_DATA,

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -67,6 +67,7 @@ enum txnouttype
     TX_PUBKEYHASH_REPLAY,
     TX_SCRIPTHASH,
     TX_MULTISIG,
+    TX_MULTISIG_REPLAY,
     TX_NULL_DATA,
 };
 


### PR DESCRIPTION
Previously replay protected transactions no longer appear to validate after the removal of all replay protection functionality.

This implementation adds the minimal modifications necessary to maintain the redeemability of previously-sent transaction replay protected transactions. No block hash checking is conducted in this implementation.