### PR TITLE
Fixed Test Failure #134

### DIFF
--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -581,7 +581,7 @@ TEST(wallet_tests, cached_witnesses_empty_chain) {
 
     // Until #1302 is implemented, this should triggger an assertion
     EXPECT_DEATH(wallet.DecrementNoteWitnesses(&index),
-                 "Assertion( `| failed: \()nWitnessCacheSize > 0");
+                 "nWitnessCacheSize > 0");
 }
 
 TEST(wallet_tests, cached_witnesses_chain_tip) {


### PR DESCRIPTION
Invalid string passed as second argument in an EXPECT_DEATH test